### PR TITLE
Criação do módulo e do endpoint de Criticas Lit.

### DIFF
--- a/src/app/criticas-literarias/criticas-literarias.module.ts
+++ b/src/app/criticas-literarias/criticas-literarias.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CriticasLiterariasComponent } from './criticas-literarias/criticas-literarias.component';
+
+
+
+@NgModule({
+  declarations: [
+    CriticasLiterariasComponent
+  ],
+  imports: [
+    CommonModule
+  ]
+})
+export class CriticasLiterariasModule { }

--- a/src/app/criticas-literarias/criticas-literarias/criticas-literarias.component.html
+++ b/src/app/criticas-literarias/criticas-literarias/criticas-literarias.component.html
@@ -1,0 +1,1 @@
+<p>criticas-literarias works!</p>

--- a/src/app/criticas-literarias/criticas-literarias/criticas-literarias.component.spec.ts
+++ b/src/app/criticas-literarias/criticas-literarias/criticas-literarias.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CriticasLiterariasComponent } from './criticas-literarias.component';
+
+describe('CriticasLiterariasComponent', () => {
+  let component: CriticasLiterariasComponent;
+  let fixture: ComponentFixture<CriticasLiterariasComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CriticasLiterariasComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CriticasLiterariasComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/criticas-literarias/criticas-literarias/criticas-literarias.component.ts
+++ b/src/app/criticas-literarias/criticas-literarias/criticas-literarias.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-criticas-literarias',
+  templateUrl: './criticas-literarias.component.html',
+  styleUrls: ['./criticas-literarias.component.scss']
+})
+export class CriticasLiterariasComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/criticas-literarias/modelos/criticasLiterarias.ts
+++ b/src/app/criticas-literarias/modelos/criticasLiterarias.ts
@@ -1,0 +1,6 @@
+export interface CriticasLiterarias {
+  _idCriticaLit:string;
+  critico:string;
+  titulo:string;
+  resumo:string;
+}

--- a/src/app/criticas-literarias/service/criticas-literarias.service.spec.ts
+++ b/src/app/criticas-literarias/service/criticas-literarias.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CriticasLiterariasService } from './criticas-literarias.service';
+
+describe('CriticasLiterariasService', () => {
+  let service: CriticasLiterariasService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CriticasLiterariasService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/criticas-literarias/service/criticas-literarias.service.ts
+++ b/src/app/criticas-literarias/service/criticas-literarias.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CriticasLiterariasService {
+
+  constructor() { }
+}

--- a/src/assets/criticasLiterarias.json
+++ b/src/assets/criticasLiterarias.json
@@ -1,0 +1,3 @@
+[{
+  "_idCriticaLit":"0","critico":"nome", "titulo":"colocar titulo", "resumo":"resumo da critica"
+}]


### PR DESCRIPTION
- [ ] Criação do módulo de críticas literárias;

- [ ] Montar um endpoint com campos para ser consumidos pelo dialogo do módulo de críticas e pelos cartões do módulo. Seguindo as informações para atender o componente visual para a aplicação de críticas criado em outro cartão de tarefa.